### PR TITLE
PHP 8.0: fix bug in the `bytes` routing code

### DIFF
--- a/lib/routes.php
+++ b/lib/routes.php
@@ -220,7 +220,7 @@ function get_routes() {
 	$routes['/bytes/<bytes>'] = function ($args) {
 		header('Content-Type: application/octet-stream');
 
-		mt_srand('RequestsPHP');
+		mt_srand(0);
 		$sent = 0;
 		$desired = min((int) $args['bytes'], 10000);
 		while ($sent < $desired) {


### PR DESCRIPTION
The PHP [`mt_srand()`](https://www.php.net/manual/en/function.mt-srand.php) function expects to receive as the first parameter an integer, however a string was given.

This has been throwing warnings since forever, but as of PHP 8.0 is now a `TypeError`. See: https://3v4l.org/4k4DG

In previous versions of PHP, the string would have been juggled to an integer, which resulted in the integer `0` being passed to the actual `mt_srand()` function call.

This fix maintains the existing behaviour in that respect, while preventing the `TypeError` on PHP 8.