### PR TITLE
Adapt bin path to changes in Composer 2.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,33 @@
+Requests for PHP Test Server
+============================
+
+This repository is a simplistic test server that is being used by the [Requests for PHP library](https://github.com/WordPress/Requests/) to run its automated testing suite.
+
+Installation
+------------
+
+This package is not meant to be used as a stand-alone server. Rather, it is being used by the CI testing workflows in the [Requests for PHP library](https://github.com/WordPress/Requests/).
+
+To install it in your local environment anyway, you can use the following command:
+
+```bash
+composer install
+```
+
+Note: This package requires **Composer v2.2+** to work correctly.
+
+Contribute
+----------
+
+1. Check for open issues or open a new issue for a feature request or a bug.
+2. Fork [the repository][] on Github to start making your changes to the
+    `develop` branch (or branch off of it).
+3. Write one or more tests which show that the bug was fixed or that the feature works as expected.
+4. Send in a pull request.
+
+If you have questions while working on your contribution and you use Slack, there is
+a [#core-http-api] channel available in the [WordPress Slack] in which contributions can be discussed.
+
+[the repository]: https://github.com/RequestsPHP/test-server/
+[#core-http-api]: https://wordpress.slack.com/archives/C02BBE29V42
+[WordPress Slack]: https://make.wordpress.org/chat/

--- a/bin/start.sh
+++ b/bin/start.sh
@@ -1,4 +1,6 @@
-SERVERDIR="$PWD/$(dirname $0)"
+# Note: The value of $0 has changed with Composer 2.2, so we're relying on
+# Composer 2.2+ as the required minimum now.
+SERVERDIR="$(dirname $0)"
 PORT=${PORT:-"80"}
 
 PHPBIN=${PHPBIN:-"$(which php)"}

--- a/bin/stop.sh
+++ b/bin/stop.sh
@@ -1,4 +1,6 @@
-SERVERDIR="$PWD/$(dirname $0)"
+# Note: The value of $0 has changed with Composer 2.2, so we're relying on
+# Composer 2.2+ as the required minimum now.
+SERVERDIR="$(dirname $0)"
 
 PIDFILE="$SERVERDIR/http.pid"
 

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
 		}
 	],
 	"require": {
-		"php": ">=5.2"
+		"php": ">=5.6"
 	},
 	"type": "library",
 	"autoload": {


### PR DESCRIPTION
With Composer 2.2, the executable path that is being used to execute binaries changes from a relative path to an absolute path.

This PR fixes the start and stop scripts to just use the executable path without prefixing it with the current working folder.

It also adds preliminary documentation in the form of a base `README.md` file.

Finally, it bumps the PHP minimum requirement to 5.6+.