### PR TITLE
Set the correct protocol for received URL requests (take 2)

### DIFF
--- a/bin/serve.php
+++ b/bin/serve.php
@@ -8,7 +8,17 @@ if ( ! function_exists( 'Requests\\TestServer\\get_routes' ) ) {
 ini_set('html_errors', false);
 header('Content-Type: application/json; charset=utf-8');
 
-$scheme   = empty($_SERVER['HTTPS']) ? 'http://' : 'https://';
+$is_secure = false;
+if (isset($_SERVER['HTTPS']) && ! empty($_SERVER['HTTPS']) ) {
+	$is_secure = true;
+}
+elseif ((!empty($_SERVER['HTTP_X_FORWARDED_PROTO']) && $_SERVER['HTTP_X_FORWARDED_PROTO'] == 'https')
+	|| (!empty($_SERVER['HTTP_X_FORWARDED_SSL']) && $_SERVER['HTTP_X_FORWARDED_SSL'] == 'on')
+) {
+	$is_secure = true;
+}
+
+$scheme   = $is_secure ? 'https' : 'http';
 $base_url = $scheme . $_SERVER['HTTP_HOST'];
 
 $headers = null;


### PR DESCRIPTION
As before:
> As things were, the server would always set the `url` to an `http` address, while the requested URL could be a `https` address.

Looks like, due to load balancing, the `$_SERVER` variable does not always get set correctly. So let's try again based on the headers.