### PR TITLE
Composer: remove `autoload` directive

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,8 +14,5 @@
 		"php": ">=5.6"
 	},
 	"type": "library",
-	"autoload": {
-		"files": [ "lib/routes.php", "lib/utils.php" ]
-	},
 	"bin": [ "bin/start.sh", "bin/stop.sh", "bin/serve.php" ]
 }


### PR DESCRIPTION
The script entry points are the `start.sh` and `serve.php` files and the `serve.php` file does a hard `require` of the files it needs anyway, so there is no need for the `autoload` directive, so let's remove it as discussed in #11.